### PR TITLE
Supervisormode

### DIFF
--- a/src/I68KProcessor.php
+++ b/src/I68KProcessor.php
@@ -26,5 +26,7 @@ interface I68KProcessor extends IDevice
     public function getRegister(string $sRegName): int;
     public function setRegister(string $sRegName, int $iValue): self;
 
+    public function setSupervisorMode(bool $isSupervisor): self;
+
 }
 

--- a/src/Processor/Opcode/IMove.php
+++ b/src/Processor/Opcode/IMove.php
@@ -84,6 +84,7 @@ interface IMove
 
 
     const OP_MOVE_2_CCR  = 0b0100010011000000;
+    const OP_MOVE_2_SR   = 0b0100011011000000;
 
     // 010+
     const OP_MOVE_CCR    = 0b0100001011000000;

--- a/src/Processor/Opcode/TMove.php
+++ b/src/Processor/Opcode/TMove.php
@@ -423,6 +423,24 @@ trait TMove
             )
         );
 
+        // Move to SR
+        $this->addExactHandlers(
+            array_fill_keys(
+                $this->generateForEAModeList(
+                    IEffectiveAddress::MODE_ALL_EXCEPT_AREGS,
+                    IMove::OP_MOVE_2_SR
+                ),
+                function (int $iOpcode) {
+                    if ($this->iStatusRegister & IRegister::SR_MASK_SUPER) {
+                        $this->iStatusRegister = $this->aSrcEAModes[$iOpcode & IOpcode::MASK_OP_STD_EA]->readWord();
+                        $this->iConditionRegister = $this->iStatusRegister & IRegister::CCR_MASK;
+                    } else {
+                        throw new LogicException('Privilege Violation: MOVE to SR');
+                    }
+                }
+            )
+        );
+
         // Move from CCR (68010+)
         $this->addExactHandlers(
             array_fill_keys(

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -5,3 +5,4 @@ php -dzend.assertions=1 test_regs.php
 php -dzend.assertions=1 test_eamodes.php
 php -dzend.assertions=1 test_op_direct.php
 php -dzend.assertions=1 test_scc.php
+php -dzend.assertions=1 test_supervisor.php

--- a/test/test_supervisor.php
+++ b/test/test_supervisor.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ABadCafe\G8PHPhousand\Test;
+
+require_once 'bootstrap.php';
+
+use ABadCafe\G8PHPhousand\TestHarness\CPU;
+use ABadCafe\G8PHPhousand\Device\Memory\SparseWordRAM;
+use ABadCafe\G8PHPhousand\Processor\IRegister;
+
+// Create a CPU
+$oCPU = new CPU(new SparseWordRAM());
+$oBus = $oCPU->getOutside();
+
+// Set and get the user stack pointer
+$oCPU->setRegister('a7', 0x12345678);
+assertSame(0x12345678, $oCPU->getRegister('a7'), 'Set/Get USP');
+
+// Switch to supervisor mode
+$oCPU->setSupervisorMode(true);
+
+// Check that the supervisor bit is set
+assertSame(IRegister::SR_MASK_SUPER, $oCPU->getRegister('sr') & IRegister::SR_MASK_SUPER, 'Supervisor bit is set');
+
+// Set and get the supervisor stack pointer
+$oCPU->setRegister('a7', 0x87654321);
+assertSame(0x87654321, $oCPU->getRegister('a7'), 'Set/Get SSP');
+
+// Switch back to user mode and check USP is unchanged
+$oCPU->setSupervisorMode(false);
+assertSame(0x12345678, $oCPU->getRegister('a7'), 'USP is unchanged');
+
+// Switch back to supervisor mode to test MOVE to SR
+$oCPU->setSupervisorMode(true);
+
+// Now use MOVE to SR to switch back to user mode
+$oCPU->setRegister('d0', 0x0000);
+$oBus->writeWord(0, 0x46C0); // move.w d0, sr
+$oCPU->executeAt(0);
+
+// Check that the supervisor bit is clear
+assertSame(0, $oCPU->getRegister('sr') & IRegister::SR_MASK_SUPER, 'Supervisor bit is clear');
+
+// Check that we are back to the user stack pointer
+assertSame(0x12345678, $oCPU->getRegister('a7'), 'Back to USP');
+
+echo "All Supervisor Tests Passed!\n";


### PR DESCRIPTION
I have added a supervisor mode.

  Here's a summary of the changes:

   * Supervisor and User Stack Pointers: The emulator now supports separate stack pointers for
     supervisor and user modes. The active stack pointer is determined by the S-bit in the
     Status Register.
   * `MOVE to SR` Instruction: The MOVE to SR instruction has been implemented to allow
     changing the Status Register. This instruction is privileged and can only be executed in
     supervisor mode.
   * Testing: A new test file, test/test_supervisor.php, has been added to verify the
     supervisor mode functionality. This test has also been added to the main test script
     test/run_tests.sh.
